### PR TITLE
Refactoring Api Calls to be independent of model logic.

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,8 +1,4 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
-    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
-
-    // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
         "andys8.jest-snippets",
         "breezelin.phpstan",
@@ -20,11 +16,11 @@
         "whatwedo.twig",
         "yzhang.markdown-all-in-one"
     ],
-    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+
     "unwantedRecommendations": [
-        "dbaeumer.jshint", // we use eslint
-        "hookyqr.beautify", // we use prettier
-        "davidanson.vscode-markdownlint", // we use prettier
+        "dbaeumer.jshint",
+        "hookyqr.beautify",
+        "davidanson.vscode-markdownlint",
         "pkosta2005.heroku-command",
         "googlecloudtools.cloudcode"
     ]

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,31 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": [
+        "andys8.jest-snippets",
+        "breezelin.phpstan",
+        "dbaeumer.vscode-eslint",
+        "eamodio.gitlens",
+        "editorconfig.editorconfig",
+        "esbenp.prettier-vscode",
+        "felixfbecker.php-debug",
+        "felixfbecker.php-intellisense",
+        "ikappas.phpcs",
+        "mehedidracula.php-namespace-resolver",
+        "orta.vscode-jest",
+        "streetsidesoftware.code-spell-checker",
+        "timonwong.shellcheck",
+        "whatwedo.twig",
+        "yzhang.markdown-all-in-one"
+    ],
+    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+    "unwantedRecommendations": [
+        "dbaeumer.jshint", // we use eslint
+        "hookyqr.beautify", // we use prettier
+        "davidanson.vscode-markdownlint", // we use prettier
+        "pkosta2005.heroku-command",
+        "googlecloudtools.cloudcode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "cSpell.words": [
+        "Unirest"
+    ]
+}

--- a/app/Destination.php
+++ b/app/Destination.php
@@ -4,6 +4,12 @@ namespace App;
 
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * Note:
+ * Models should alwyes be where you store quired
+ * and should alwyes be returning arrays/Collections
+ */
+
 class Destination extends Model
 {
     protected $table = 'destinations';
@@ -14,60 +20,8 @@ class Destination extends Model
         'destination_id'
         ];
 
-    /*
-    public function inDatabase($search)
+    public function listByName(string $name)
     {
-        if (Destination::where('name', 'LIKE', '%'. $search. '%')->exists()) {
-            $destination=Destination::where('name', 'LIKE', '%'. $search. '%')->get()->toJson(JSON_PRETTY_PRINT);
-            return response($destination);
-         }
+        return $this->where('name', 'LIKE', '%' . $name . '%')->take(3)->get();
     }
-
-*/
-
-    public function listProperties($destinationId, $checkIn, $checkOut,$adults=1, $children=0){
-        $response = \Unirest\Request::get("https://hotels4.p.rapidapi.com/properties/list?currency=USD&locale=en_US&sortOrder=PRICE&destinationId={$destinationId}&pageNumber=1&checkIn={$checkIn}&checkOut={$checkOut}&pageSize=25&adults1={$adults}&children1={$children}",
-        array(
-          "X-RapidAPI-Host" => "hotels4.p.rapidapi.com",
-          "X-RapidAPI-Key" => "7d6f037ee1msh7f9148c2f5901c2p17cc79jsnc16226e926d4"
-        )
-      );
-      dd($response->body);
-    }
-    public function getDestinationFromHotelsApi($destination){
-        $response = \Unirest\Request::get("https://hotels4.p.rapidapi.com/locations/search?locale=en_US&query={$destination}",
-        array(
-          "X-RapidAPI-Host" => "hotels4.p.rapidapi.com",
-          "X-RapidAPI-Key" => "7d6f037ee1msh7f9148c2f5901c2p17cc79jsnc16226e926d4"
-        )
-        );
-        //dd($response->body->suggestions[0]->entities[0]);
-
-        Destination::firstOrCreate([
-            'name' => $response->body->suggestions[0]->entities[0]->name,
-            'longitude' => $response->body->suggestions[0]->entities[0]->longitude,
-            'latitude'=>$response->body->suggestions[0]->entities[0]->latitude,
-            'destination_id'=>$response->body->suggestions[0]->entities[0]->destinationId,
-            //'dummy'=>$$response->body->suggestions[0]->entities[0]->latitude
-        ]);
-
-    }
-
-
-    /*
-    public function getDestinationFromTripAdvisorApi(){
-        $response = Unirest\Request::get("https://tripadvisor1.p.rapidapi.com/answers/list?limit=10&question_id=5283833",
-        array(
-            "X-RapidAPI-Host" => "tripadvisor1.p.rapidapi.com",
-            "X-RapidAPI-Key" => "7d6f037ee1msh7f9148c2f5901c2p17cc79jsnc16226e926d4"
-        )
-        );
-         Destination::firstOrCreate([
-            'name' => $response->body->suggestions[0]->entities[0]->name,
-            'longitude' => $response->body->suggestions[0]->entities[0]->longitude,
-            'latitude'=>$response->body->suggestions[0]->entities[0]->latitude,
-            'zipcode'=>$response->body->suggestions[0]->entities[0]->name,
-            //'dummy'=>$$response->body->suggestions[0]->entities[0]->longitud
-        ]);
-    }*/
 }

--- a/app/Http/Controllers/SearchController.php
+++ b/app/Http/Controllers/SearchController.php
@@ -3,22 +3,24 @@
 namespace App\Http\Controllers;
 
 use App\Destination;
+use App\Services\RapidApiService;
 use Illuminate\Http\Request;
 
 class SearchController extends Controller
 {
-    public static function getDestinationId($destinationName){
-        $destinationId= Destination::select('destination_id')
-        ->where('name', '=', $destinationName)
-        ->get();
+    public static function getDestinationId($destinationName)
+    {
+        $destinationId = Destination::select('destination_id')
+            ->where('name', '=', $destinationName)
+            ->get();
         return $destinationId;
     }
-    public function index(Request $request, Destination $destination)
-{
-    $search = $_GET['search'];
-    $checkIn = $_GET['checkIn'];
-    $checkOut = $_GET['checkOut'];
-    $destinationId = 10233105;
-    $destination->listProperties($destinationId,$checkIn,$checkOut);
-}
+    public function index(Request $request, Destination $destination,RapidApiService $rapidApiService)
+    {
+        $search = $_GET['search'];
+        $checkIn = $_GET['checkIn'];
+        $checkOut = $_GET['checkOut'];
+        $destinationId = 10233105;
+        $rapidApiService->listProperties($destinationId, $checkIn, $checkOut);
+    }
 }

--- a/app/Services/RapidApiService.php
+++ b/app/Services/RapidApiService.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Services;
+
+use App\Destination;
+use Illuminate\Support\Facades\Log;
+
+use function GuzzleHttp\Psr7\build_query;
+
+class RapidApiService
+{
+    public function __construct($host = 'hotels4.p.rapidapi.com', $key = '7d6f037ee1msh7f9148c2f5901c2p17cc79jsnc16226e926d4')
+    {
+        $this->baseUrl =  'https://hotels4.p.rapidapi.com';
+        $this->header = array(
+            "X-RapidAPI-Host" => $host,
+            "X-RapidAPI-Key" => $key
+        );
+    }
+
+    public function listProperties($destinationId, $checkIn, $checkOut, $adults = 1, $children = 0)
+    {
+        $query = [
+            'currency' => 'US',
+            'locale' => 'en_US',
+            'sortOrder' => 'PRICE',
+            'destinationId' => $destinationId,
+            'pageNumber' => 1,
+            'pageSize' => 25,
+            'checkIn' => $checkIn,
+            'checkOut' => $checkOut,
+            'adults1' => $adults,
+            'children1' => $children
+        ];
+        \Unirest\Request::get(
+            "{$this->baseUrl}/properties/list?" . build_query($query),
+            $this->header
+        );
+        /**
+         *  Or better you can call
+         *  $this->request('/properties/list',$query);
+         *  */
+    }
+
+
+    public function getDestinationFromHotelsApi($destination)
+    {
+        $query = [
+            'currency' => 'US',
+            'query' => $destination
+        ];
+        $response = \Unirest\Request::get(
+            "{$this->baseUrl}/locations/search?" . build_query($query),
+            $this->header
+        );
+
+        if ($response->code !== 200) {
+            Log::alert("Api return an error raw_body {$response->raw_body} ");
+            return;
+        }
+
+        Destination::firstOrCreate(
+            [
+                'name' => $response->body->suggestions[0]->entities[0]->name,
+                'longitude' => $response->body->suggestions[0]->entities[0]->longitude,
+                'latitude' => $response->body->suggestions[0]->entities[0]->latitude,
+                'destination_id' => $response->body->suggestions[0]->entities[0]->destinationId
+            ]
+        );
+    }
+
+    /**
+     * A function that calls api using the defualt of the class in constructor
+     */
+    private function request(string $path, array $query)
+    {
+        return \Unirest\Request::get(
+            "{$this->baseUrl}/$path?" . build_query($query),
+            $this->header
+        );
+    }
+}

--- a/app/Services/TripAdvisorApi.php
+++ b/app/Services/TripAdvisorApi.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Services;
+
+use App\Destination;
+use Illuminate\Support\Facades\Log;
+
+use function GuzzleHttp\Psr7\build_query;
+
+class TripAdvisorApi
+{
+    public function __construct($host = 'tripadvisor1.p.rapidapi.com', $key = '7d6f037ee1msh7f9148c2f5901c2p17cc79jsnc16226e926d4')
+    {
+        $this->baseUrl =  'https://tripadvisor1.p.rapidapi.com';
+        $this->header = array(
+            "X-RapidAPI-Host" => $host,
+            "X-RapidAPI-Key" => $key
+        );
+    }
+
+
+    public function getDestinationFromTripAdvisorApi()
+    {
+
+        $response = $this->request(
+            'answers/list',
+            [
+                'limit' => 10,
+                'question_id' => 5283833
+            ]
+        );
+
+        Destination::firstOrCreate([
+            'name' => $response->body->suggestions[0]->entities[0]->name,
+            'longitude' => $response->body->suggestions[0]->entities[0]->longitude,
+            'latitude' => $response->body->suggestions[0]->entities[0]->latitude,
+            'zipcode' => $response->body->suggestions[0]->entities[0]->name,
+            //'dummy'=>$$response->body->suggestions[0]->entities[0]->longitud
+        ]);
+    }
+
+    private function request(string $path, array $query)
+    {
+        return \Unirest\Request::get(
+            "{$this->baseUrl}/$path?" . build_query($query),
+            $this->header
+        );
+    }
+}


### PR DESCRIPTION
previously the model classes where doing API calls directly inside its logic and controller were doing a direct query on models. 
## what this pr do. 
- moving the API logic into a new services namespace.
- moving queries from the controller into models. 
- general cleanup. 

## what's next 
now that API's are independent classes that is being injected as a service we can easily tell Laravek to provide a mock of the class that contains a different logic to fill DB with entries. 
