### PR TITLE
Adding a simple api mock.

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Services\RapidApiService;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -23,6 +24,11 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        $this->app->bind(
+            RapidApiService::class,
+            function ($app) {
+                return new \App\Services\RapidApiServiceMock();
+            }
+        );
     }
 }

--- a/app/Services/RapidApiServiceMock.php
+++ b/app/Services/RapidApiServiceMock.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Services;
+
+use App\Destination;
+use Faker\Factory as Faker;
+
+class RapidApiServiceMock extends RapidApiService
+{
+    public function __construct()
+    {
+        $this->faker = Faker::create();;
+    }
+
+    public function listProperties($destinationId, $checkIn, $checkOut, $adults = 1, $children = 0)
+    {
+        // use faker to return and array from here
+    }
+
+
+    public function getDestinationFromHotelsApi($search)
+    {
+        $imaginaryCity = $search . $this->faker->city;
+        Destination::firstOrCreate(
+            [
+                'name' => $imaginaryCity,
+                'longitude' => $this->faker->longitude,
+                'latitude' => $this->faker->latitude,
+                'destination_id' => bin2hex($imaginaryCity)
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## What this pr Do 
- binding `RapidApiServiceMock` on every `RapidApiService ` instance. in a way that we can easily remove later without code change. 

- use faker for better data.